### PR TITLE
Update InputfieldPageTableExtended.module

### DIFF
--- a/InputfieldPageTableExtended.module
+++ b/InputfieldPageTableExtended.module
@@ -42,6 +42,9 @@ class InputfieldPageTableExtended extends InputfieldPageTable {
 	        $layout = "";
 	        foreach($pagesToRender as $p){
 	        	$layoutTitle = $p->template->label ? $p->template->label : $p->template->name;
+	        	$parsedTemplate = new TemplateFile($this->config->paths->templates . $p->template->name . ".php");
+                	$parsedTemplate->page = $p;
+                	$parsedTemplate->options = array('pageTableExtended' => true);
 	        	$layout .= '
 	        				<tr data-id="'.$p->id.'">
 	        					<td width="95%">
@@ -49,7 +52,7 @@ class InputfieldPageTableExtended extends InputfieldPageTable {
 	        							<i class="toggle-icon fa fa-angle-down"></i>
 	        						</a>
 	        						<span class="renderedLayoutTitle inactive">'.$layoutTitle.'</span>
-	        						<div class="renderedLayout active">'.$p->render(array('pageTableExtended' => true)).'</div>
+	        						<div class="renderedLayout active">'.$parsedTemplate->render().'</div>
 	        					</td>
 	        					<td width="5%">
 	        						<a class="InputfieldPageTableEdit" data-url="./?id='.$p->id.'&amp;modal=1" href="#">


### PR DESCRIPTION
Module actually breaks in some template delegation scenarios (the content of the PageTable page gets displayed on the frontend instead of showing the admin edit page!), though it may only be me affected at present.

These changes fetch the template as a separate template object and parse in the data, then render the parsed template so ProcessWire doesn't accidentally render the wrong page.

Not sure if it was affecting other people, but it should work in all obscure template delegation cases anyway and doesn't seem to have any downsides that I can see.

Passed $p to the template too as well as the options array so will be backwards compatible with your current instructions.
