### PR TITLE
Support custom template- and rendering-engines

### DIFF
--- a/InputfieldPageTableExtended.module
+++ b/InputfieldPageTableExtended.module
@@ -74,7 +74,7 @@ class InputfieldPageTableExtended extends InputfieldPageTable {
 	        							<i class="toggle-icon fa '.$iconClass.'"></i>
 	        						</a>
 	        						<span class="renderedLayoutTitle '.$activeClass.'">'.$layoutTitle.'</span>
-	        						<div class="renderedLayout '.$activeClass.$statusClass.'">'.$parsedTemplate->render().'</div>
+	        						<div class="renderedLayout '.$activeClass.$statusClass.'">'.$parsedTemplate->page->render().'</div>
 	        					</td>
 	        					<td width="5%">
 	        						<a class="InputfieldPageTableEdit" data-url="./?id='.$p->id.'&amp;modal=1" href="#">


### PR DESCRIPTION
Hi Marc,
I've made some minor changes to let your module support custom rendering engines and template extensions:
In our case we're using the existing "$config->templateExtension" and set it to ".twig" (which wasn't supported by your module as you've hardcoded .php as the templates extension).
Furthermore I've changed the $parsedTemplate->render() call to render the page instead of just the template file as most modules hook to PageRender::renderPage to alter the templates output. Maybe this should be made configurable (for people using the "delegate approach")?
