### PR TITLE
Item templates should use "Alternate Template Filename" setting if it ex...

### DIFF
--- a/InputfieldPageTableExtended.module
+++ b/InputfieldPageTableExtended.module
@@ -46,7 +46,7 @@ class InputfieldPageTableExtended extends InputfieldPageTable {
 
 	        	$layoutTitle = $p->template->label ? $p->template->label : $p->template->name;
 
-	        	$parsedTemplate = new TemplateFile($this->config->paths->templates . $this->pathToTemplates  . $p->template->name . '.' . wire('config')->templateExtension);
+	        	$parsedTemplate = new TemplateFile($p->template->filename);
             	$parsedTemplate->page = $p;
             	$parsedTemplate->options = array('pageTableExtended' => true);
 				$parsedTemplate->page->of(true); // set OutputFormatting to true


### PR DESCRIPTION
...ists

If the template for an item has the "Alternate Template Filename" setting set, it will now be used instead of just assuming that a file with the exact template name exists in the templates directory.
