### PR TITLE
bump version number for prior change

### DIFF
--- a/InputfieldPageTableExtended.module
+++ b/InputfieldPageTableExtended.module
@@ -6,7 +6,7 @@ class InputfieldPageTableExtended extends InputfieldPageTable {
 		return array(
 			'title' => __('Inputfield for PageTableExtended', __FILE__), // Module Title
 			'summary' => __('Adds Inputfield for PageTableExtended', __FILE__), // Module Summary
-			'version' => 22,
+			'version' => '221',
 			'requires' => array('FieldtypePageTableExtended'),
 			'permanent' => false, 
 		);


### PR DESCRIPTION
It will be handy to be able to differentiate between the version of this module that has the "altFilename" handling versus the older version that doesn't (specifically for a module I'm finishing up that relies on this... will be helpful if I can tell people "you must be using at least version 2.2.1 of PageTableExtended"). Thanks!
