### PR TITLE
make `$options['pageTableExtended']` work again

### DIFF
--- a/InputfieldPageTableExtended.module
+++ b/InputfieldPageTableExtended.module
@@ -73,7 +73,7 @@ class InputfieldPageTableExtended extends InputfieldPageTable {
 	        							<i class="toggle-icon fa '.$iconClass.'"></i>
 	        						</a>
 	        						<span class="renderedLayoutTitle '.$activeClass.'">'.$layoutTitle.'</span>
-	        						<div class="renderedLayout '.$activeClass.$statusClass.'">'.$parsedTemplate->page->render().'</div>
+	        						<div class="renderedLayout '.$activeClass.$statusClass.'">'.$parsedTemplate->render().'</div>
 	        					</td>
 	        					<td width="5%">
 	        						<a class="InputfieldPageTableEdit" data-url="./?id='.$p->id.'&amp;modal=1" href="#">


### PR DESCRIPTION
The `$option['pageTableExtended']` setting was not being passed through to the actual template... I think because the template is what should be rendered as opposed to the template's page.
