### PR TITLE
Fix for "path to templates" setting and some other tweaks

### DIFF
--- a/InputfieldPageTableExtended.module
+++ b/InputfieldPageTableExtended.module
@@ -47,11 +47,15 @@ class InputfieldPageTableExtended extends InputfieldPageTable {
 				$layoutTitle = $p->template->label ? $p->template->label : $p->template->name;
 				$ext = "." . $this->config->templateExtension;
 				$template_name = $p->template->altFilename ? basename($p->template->altFilename, $ext) : $p->template->name;
-				$parsedTemplate = new TemplateFile($this->config->paths->templates . $this->pathToTemplates  . $template_name . $ext);
-				$parsedTemplate->page = $p;
-				$parsedTemplate->options = array('pageTableExtended' => true);
+				$templateFilename = $this->pathToTemplates  . $template_name . $ext;
 
-				$parsedTemplate->page->of(true); // set OutputFormatting to true
+				$options = array(
+					'pageTableExtended' => true,
+					'prependFile' => null,
+					'appendFile' => null);
+				
+				$p->template->filename = $templateFilename; // Otherwise PW throws error notice
+				$p->of(true); // set OutputFormatting to true
 
 				$iconClass = "fa-angle-down";
 				$activeClass = "pte-open";
@@ -73,7 +77,7 @@ class InputfieldPageTableExtended extends InputfieldPageTable {
 	        							<i class="toggle-icon fa '.$iconClass.'"></i>
 	        						</a>
 	        						<span class="renderedLayoutTitle '.$activeClass.'">'.$layoutTitle.'</span>
-	        						<div class="renderedLayout '.$activeClass.$statusClass.'">'.$parsedTemplate->page->render(array('pageTableExtended' => true)).'</div>
+	        						<div class="renderedLayout '.$activeClass.$statusClass.'">'.$p->render($templateFilename, $options).'</div>
 	        					</td>
 	        					<td width="5%">
 	        						<a class="InputfieldPageTableEdit" data-url="./?id='.$p->id.'&amp;modal=1" href="#">


### PR DESCRIPTION
Hi Marc! Just played today with PageTableExtended and I really liked! Very good work! I had problems with "path to templates" setting - I wanted to put my markup in /site/templates/blocks/ folder but it never found them from there, event that I had pathToTemplates setting as "blocks/". I dived into code and found some problems from renderTable method. Here is fix and hopefully tweaks that cleans the code a little bit - I didn't understand the meaning of $parsedTemplate, so removed that. Also added few more options that are relevant to delegate approach - I disabled prepend and append templates. I don't think those are ever needed? Append templates usually render whole layout and prepend templates can have relative includes that will throw errors if used from other directory.
